### PR TITLE
Exception handling (physical mining problem) in LastMile dispatching.

### DIFF
--- a/specification/LastMileDispatchingExceptionV1.md
+++ b/specification/LastMileDispatchingExceptionV1.md
@@ -17,7 +17,8 @@ This message is sent by `AHS` to tells the `Last Mile Dispatching` that this veh
 |`"VehicleId"`| VehicleId | UUID| The vehicle that has encountered a problem while being managed by the last mile dispatching process|
 |`"LastMileId"`| DispatchingId | UUID| A unique ID for this dispatching that will remain the same throught the process of last mile dispatching the truck to the spot and until the truck is released from the Last Mile dispatching process.|
 |`"PlaceId"`| WayId| uint_64|The next place the vehicle is trying to reach but has encountered an exception during its locomotion there|
-|`"Description"`|Human readable text|string| A human readable error message that explains what problem the truck has encountered and possibly a proposed resolution.
+|`"ExceptionId"` | AHS Specific | uint_64 | An out of specification pre-agreed number that the last mile dispatching can use to match a human readable description of the exception and/or automate a workflow |
+|`"Description"`|`nullable` Human readable text|string| A human readable error message that explains what problem the truck has encountered and possibly a proposed resolution.  This field is optional, but it is expected that when null, the AHS has provided the LMD with documentation for each number with a description and possibly a remediation to the exception.
 
 
 ## Use Case:
@@ -43,6 +44,7 @@ While driving to the final spot `731853`, Truck `be87fb7e-9eb6-11ed-a8fc-0242ac1
     "VehicleId": "be87fb7e-9eb6-11ed-a8fc-0242ac120002",
     "LastMileId":"23456756-aa34-5742-9b66-08a5d4294f34",
     "PlaceId": 731853,
+    "ExceptionId": 27,
     "Description":"I've fallen and I can't get up."
   }
 

--- a/specification/LastMileDispatchingExceptionV1.md
+++ b/specification/LastMileDispatchingExceptionV1.md
@@ -1,0 +1,108 @@
+# LastMileDispatchingExceptionV1
+This message is sent by `AHS` to tells the `Last Mile Dispatching` that this vehicle hit a snag and can't reach its next position in the spotting chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `Last Mile dispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
+> NOTE-1 that the destination in the OccupyPlace message **could** change as a result of fixing the exception.<br>
+> NOTE-2 It is expected that the `AHS` wouls also send an ISO-23725 VehicleDiagnosticV2 to the FMS at the same time.
+
+<br>
+
+|Sender| Triggered by | Triggers|
+|---|---|---|
+| `AHS`| truck is stuck but intends to complete spotting | A manual SOP that will correct the truck exception.  Once corrected, a person will tell `Last Mile Dispatching` to re-issue a service chain to the truck using an `OccupyPlaceV1` message. |
+
+<br>
+
+## Message attributes
+|key |value |format | Description|
+|---|:---:|:---:|---|
+|`"VehicleId"`| VehicleId | UUID| The vehicle that has encountered a problem while being managed by the last mile dispatching process|
+|`"LastMileId"`| DispatchingId | UUID| A unique ID for this dispatching that will remain the same throught the process of last mile dispatching the truck to the spot and until the truck is released from the Last Mile dispatching process.|
+|`"PlaceId"`| WayId| uint_64|The next place the vehicle is trying to reach but has encountered an exception during its locomotion there|
+|`"Description"`|Human readable text|string| A human readable error message that explains what problem the truck has encountered and possibly a proposed resolution.
+
+
+## Use Case:
+This message is used by `AHS` to receive human help to complete the spotting for a truck.  This can happen at the loading face while spotting close to a heavy equipment, at the dump or crusher or even in a parking.  The causes are endless but here are a few:
+* an obstacle is detected on the vehicle's trajectory
+* an other vehicle is in the way or too close for the truck to proceed
+* the vehicle can't maneuver to that position
+
+
+
+
+## Example
+While driving to the final spot `731853`, Truck `be87fb7e-9eb6-11ed-a8fc-0242ac120002` encountered a tumbleweed on its path and sees it as a large obstacle.  The truck believes it can't proceed safely and wants human confirmation what to do next. The truck calls in the obstacle through the AHS interface and tells the last mile dispatching it has an issue:  
+
+```json
+{
+  "Protocol":"Open-Autonomy",
+  "Version": 1,
+  "Timestamp": "2023-06-27T07:33:51.540Z",
+
+  "LastMileDispatchingExceptionV1":
+  {
+    "VehicleId": "be87fb7e-9eb6-11ed-a8fc-0242ac120002",
+    "LastMileId":"23456756-aa34-5742-9b66-08a5d4294f34",
+    "PlaceId": 731853,
+    "Description":"I've fallen and I can't get up."
+  }
+
+}
+```
+
+A remote operator in the ROC received the alarm from the truck through the AHS UI and is looking at the truck's cameras to identify the problem and resolution.  The operator tells the truck to ignore the obstacle by disabling the obstacle detection for that particular obstacle (the tumbleweed).  After this, the operator tells the Last Mile dispatching to continue with the truck using the same spot.  So the Last Mile Dispatching sends this message to the truck:
+
+
+```json
+{
+  "Protocol":"Open-Autonomy",
+  "Version": 1,
+  "Timestamp": "2023-01-23T09:30:10.435Z",
+
+  "OccupyPlaceV1":
+  {
+    "VehicleId": "be87fb7e-9eb6-11ed-a8fc-0242ac120002",
+    "LastMileId": "23456756-aa34-5742-9b66-08a5d4294f34",
+    "QueueIdPrimary": 0,
+    "QueueIdStage": 0,
+    "SpotId": 731853
+  },
+
+  "SpotV1":
+  {
+    "TimeCreation":"2023-01-23T09:30:10.43.512Z",
+    "PlaceId":731853,
+    "Latitude":49.176854,
+    "Longitude":-123.0718,
+    "Elevation":22.69,
+    "Heading":68,
+    "PlaceIO":"BackIn",
+    "Origin":"Load",
+    "DynamicPathId":8456,
+    "ServiceMaxUtilization":null,
+    "PlaceState": "Opened",
+    "ChangeSequence": 3452,
+    "ServicingVehicleGUID": null,
+    "ServiceCount":0,
+    "Action":"Load",
+    "OwnerWayId":745932,
+    "OwnerGUID":"2248d535-3daf-4a86-b1e1-4951a22beec6",
+    "ServiceChain":
+    [
+      {
+        "LinkWayId": 945723,
+        "LinkQueuePrimary": 30354,
+        "LinkQueueStage":[ 30476 ]
+      },
+      {
+        "LinkWayId": 945361,
+        "LinkQueuePrimary": 30352,
+        "LinkQueueStage":[ 30475,30477]
+      }	   
+    ]
+  }
+
+
+}
+```
+
+Now the truck resumes spotting normally and gets loaded.

--- a/specification/LastMileDispatchingExceptionV1.md
+++ b/specification/LastMileDispatchingExceptionV1.md
@@ -1,5 +1,5 @@
 # LastMileDispatchingExceptionV1
-This message is sent by `AHS` to tells the `LastMileDispatching` that this vehicle hit a snag and can't reach its next position in the spotting chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `LastMileDispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
+This message is sent by `AHS` to tells the `LastMileDispatching` that this vehicle hit a snag and can't reach its next position in the service chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `LastMileDispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
 > NOTE-1 that the destination in the OccupyPlace message **could** change as a result of fixing the exception.<br>
 > NOTE-2 It is expected that the `AHS` wouls also send an ISO-23725 VehicleDiagnosticV2 to the FMS at the same time.
 

--- a/specification/LastMileDispatchingExceptionV1.md
+++ b/specification/LastMileDispatchingExceptionV1.md
@@ -1,7 +1,7 @@
 # LastMileDispatchingExceptionV1
 This message is sent by `AHS` to tells the `LastMileDispatching` that this vehicle hit a snag and can't reach its next position in the service chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `LastMileDispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
 > NOTE-1 that the destination in the OccupyPlace message **could** change as a result of fixing the exception.<br>
-> NOTE-2 It is expected that the `AHS` wouls also send an ISO-23725 VehicleDiagnosticV2 to the FMS at the same time.
+> NOTE-2 It is expected that the `AHS` would also send an ISO-23725 VehicleDiagnosticV2 to the FMS at the same time.
 
 <br>
 

--- a/specification/LastMileDispatchingExceptionV1.md
+++ b/specification/LastMileDispatchingExceptionV1.md
@@ -1,5 +1,5 @@
 # LastMileDispatchingExceptionV1
-This message is sent by `AHS` to tells the `Last Mile Dispatching` that this vehicle hit a snag and can't reach its next position in the spotting chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `Last Mile dispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
+This message is sent by `AHS` to tells the `LastMileDispatching` that this vehicle hit a snag and can't reach its next position in the spotting chain, but that the vehicle intends to continue to the final destination after the exception is resolved via external means.  It also means that `AHS` is now expecting the `LastMileDispatching` to send it a new `OccupyPlace` message when the exception is resolved and when the truck can try again.
 > NOTE-1 that the destination in the OccupyPlace message **could** change as a result of fixing the exception.<br>
 > NOTE-2 It is expected that the `AHS` wouls also send an ISO-23725 VehicleDiagnosticV2 to the FMS at the same time.
 
@@ -17,7 +17,7 @@ This message is sent by `AHS` to tells the `Last Mile Dispatching` that this veh
 |`"VehicleId"`| VehicleId | UUID| The vehicle that has encountered a problem while being managed by the last mile dispatching process|
 |`"LastMileId"`| DispatchingId | UUID| A unique ID for this dispatching that will remain the same throught the process of last mile dispatching the truck to the spot and until the truck is released from the Last Mile dispatching process.|
 |`"PlaceId"`| WayId| uint_64|The next place the vehicle is trying to reach but has encountered an exception during its locomotion there|
-|`"ExceptionId"` | AHS Specific | uint_64 | An out of specification pre-agreed number that the last mile dispatching can use to match a human readable description of the exception and/or automate a workflow |
+|`"ExceptionId"` | AHS Specific | uint_64 | An out of specification, AHS specific and pre-defined number that the last mile dispatching can use to match with a human readable description of the exception and/or automate a workflow |
 |`"Description"`|`nullable` Human readable text|string| A human readable error message that explains what problem the truck has encountered and possibly a proposed resolution.  This field is optional, but it is expected that when null, the AHS has provided the LMD with documentation for each number with a description and possibly a remediation to the exception.
 
 

--- a/specification/LeavePlaceV1.md
+++ b/specification/LeavePlaceV1.md
@@ -13,7 +13,7 @@ This message represents what is called a **truck kickout** in the industry.  Thi
 ## Message attributes
 |key |value |format | Description|
 |---|:---:|:---:|---|
-|`"PlaceId"`| WayId| uint_64| The spot an operator wants the truck to vacate.|
+|`"PlaceId"`| PlaceId | uint_64| The spot an operator wants the truck to vacate.|
 |`"VehicleId"`| VehicleId| UUID| The vehicle that need to leave the spot.|
 |`"LastMileId"` | DispatchingId | UUID | A unique ID for this dispatching that will remain the same throught the process of dispatching the truck to the spot and until the truck is released from the Last Mile dispatching process.|
 

--- a/specification/OccupyPlaceV1.md
+++ b/specification/OccupyPlaceV1.md
@@ -1,19 +1,20 @@
 # OccupyPlaceV1
 
-An Occupy place message is a mini-dispatching instruction set on how to reach a spot while in an open area.  Historically, open areas were not managed by fleet management systems for manned systems.
+The Occupy place message is a mini-dispatching instruction set on how to reach a spot while in an open area.  Historically, open areas were not managed by fleet management systems for manned systems, so there is no equivalent in a manned operation.
 
 
 |Sender| Triggered by | Triggers|
 |---|---|---|
-|`Spot` | `ApproachingLastMileV1` message| nothing immediate|
+|`Spot` | `ApproachingLastMileV1` message| truck movement in open area|
 
 <br>
 
-This message gives explicit permissions, to a truck identified by the VehicleID, to use the listed resource(s). The message will including all the resources the truck currently possesses (not just added permissions).   The truck will have to Release each resource once it leaves that resource via the `LeftPlaceV1` message.  Even if the truck does not stop at the resource, the truck must release the place once it passes that LLE position so it’s released for other trucks to use.
+This message gives explicit permissions, to a truck identified by the VehicleID, to use the listed place(s). The message will including all the places the truck currently possesses (not just added permissions).   The truck will have to Release each Place once it leaves that resource via the [`LeftPlaceV1`](LeftPlaceV1.md) message.  Even if the truck does not stop at the resource, the truck must release the place once it passes that LLE position so it’s released for other trucks to use.
 
 A place permission value of `0` will be set to mean that the vehicle does NOT have permission for a place type.  Multiple `OccupyPlace` messages can be sent to the same truck during the last mile dispatching.  Each new message from the spot service overwrites the previous permissions.  A truck that has had its permission revoked while it was moving to THAT place that just got revoked must stop (in a controlled normal manner) and wait for a new `OccupyPlace` messages.
 
 > IMPORTANT NOTE: Previously granted resources can be removed or changed in a later OccupyPlace message.  
+
 
 The message envelop will also contain a copy of all objects representing the resources the vehicle is given permission to.  Not only is this convenient for the client software, it is primiraly there to prevent race conditions or the usage of stale cached objects on the client side.
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -38,7 +38,7 @@ Find below the Specification for the Version 1 protocol for the spot service of 
 ### [OccupyPlaceV1](OccupyPlaceV1.md)
 ### [TaskStartV1](TaskStartV1.md)
 ### [LeavePlaceV1](LeavePlaceV1.md)
-### [ExpelVehicleV1](ExpelVehicleV1.md)
+### [VehicleDismissedV1](VehicleDismissedV1.md)
 # Cache Management
 ### [PlaceSummaryV1](PlaceSummaryV1.md)
 ### [PlaceAllV1](PlaceAllV1.md)

--- a/specification/README.md
+++ b/specification/README.md
@@ -55,7 +55,7 @@ Find below the Specification for the Version 1 protocol for the spot service of 
 ### [LeftPlaceV1](LeftPlaceV1.md)
 ### [OccupyingPlaceV1](OccupyingPlaceV1.md)
 ### [PlaceCommandV1](PlaceCommandV1.md)
-### [SetDynamicPathIDV1](SetDynamicPathIDV1.md)
+### [SetDynamicPathIdV1](SetDynamicPathIDV1.md)
 ---
 
 <br>

--- a/specification/README.md
+++ b/specification/README.md
@@ -50,6 +50,7 @@ Find below the Specification for the Version 1 protocol for the spot service of 
 
 # Autonomous truck messaging
 ### [ApproachingLastMileV1](ApproachingLastMileV1.md)
+### [LastMileDispatchingExceptionV1](LastMileDispatchingExceptionV1.md)
 ### [LastMileDispatchingQuitV1](LastMileDispatchingQuitV1.md)
 ### [LeftPlaceV1](LeftPlaceV1.md)
 ### [OccupyingPlaceV1](OccupyingPlaceV1.md)

--- a/specification/README.md
+++ b/specification/README.md
@@ -38,6 +38,7 @@ Find below the Specification for the Version 1 protocol for the spot service of 
 ### [OccupyPlaceV1](OccupyPlaceV1.md)
 ### [TaskStartV1](TaskStartV1.md)
 ### [LeavePlaceV1](LeavePlaceV1.md)
+### [ExpelVehicleV1](ExpelVehicleV1.md)
 # Cache Management
 ### [PlaceSummaryV1](PlaceSummaryV1.md)
 ### [PlaceAllV1](PlaceAllV1.md)

--- a/specification/SetDynamicPathIDV1.md
+++ b/specification/SetDynamicPathIDV1.md
@@ -1,33 +1,76 @@
-# MessageV1
-A summary of what it does
+# SetDynamicPathIdV1
+This is the method for an AHS to tell **IF** and **HOW** it can reach a Place in an open area.
+
 
 |Sender| Triggered by | Triggers|
 |---|---|---|
-| `spot` \|\| 'AHS' \|\| 'client'| `message` \|\| "real works event" | `message` \|\| "real works event" |
+| `AHS` | a Place changed and it has no DynamicPath associated with it | AHS to compute if it can theoritically drive there |
 
 <br>
 
 ## Message properties
 |key |value |format | Description|
 |---|:---:|:---:|---|
-|`""`||||
-|`""`||||
-|`""`||||
+|`"StartPlaceId"`| PlaceId|uint_64| place where the DynamicPathId starts from|
+|`"EndPlaceId"`| PlaceId|uint_64| place where the DynamicPathId ends|
+|`"DynamicPathId"`|`null`<br> 0 <br> PathId |uint_64| A Path ID that can be used to retrieved the path geometry from the Path service. `0` has a reserved meaning.  0 means that the AHS can't compute a theoritical path to the place and that the place needs to change if you want a truck to successfully reach it. |
 
+> The Path service is part of the Open-Autonomy family of protocols.  Please reference the Path service documentation for the techincal details.
+
+> NOTE: in the future when there will be more than one AHS operating in the same area using the same Spot service, then this field will have to be replaced by an array[] of {AHS_UUID and PathId} pairs so each AHS can seperately voice their plans or grievances .  Or it coudl be done now at the cost of added complexity.
 
 ## Use Case:
 This message is used when an event triggers it in a very special case under specific circumstances.
 
 ## Example
-This example would be for a future version that would support multiple scopes.
+AHS has computed a successful path intent and conveys this to the spot service.
 ```json
 {
   "Protocol":"Open-Autonomy",
   "Version": 1,
   "Timestamp": "2023-01-24T09:30:10.948Z",
 
-  "V1":
+  "SetDynamicPathIdV1":
   {
+    "StartPlaceId": 731889,
+    "StartPlaceId": 731858,
+    "DynamicPathId": 58311
+  }
+}
+```
+
+AHS was unsuccessful at finding a theoretical path to reach the place.
+```json
+{
+  "Protocol":"Open-Autonomy",
+  "Version": 1,
+  "Timestamp": "2023-01-24T09:30:10.948Z",
+
+  "SetDynamicPathIdV1":
+  {
+    "StartPlaceId": 731889,
+    "StartPlaceId": 731858,
+    "DynamicPathId": 0
+  }
+}
+```
+
+<br>
+AHS wants to remove an intended path or delete an "I can't reach the place".  
+
+> Note that not setting the `"DynamicPathId"` in the JSON will have the same behavior in most , if not all, libraries.
+
+```json
+{
+  "Protocol":"Open-Autonomy",
+  "Version": 1,
+  "Timestamp": "2023-01-24T09:30:10.948Z",
+
+  "SetDynamicPathIdV1":
+  {
+    "StartPlaceId": 731889,
+    "StartPlaceId": 731858,
+    "DynamicPathId": null
   }
 }
 ```

--- a/specification/SetDynamicPathIDV1.md
+++ b/specification/SetDynamicPathIDV1.md
@@ -33,7 +33,7 @@ AHS has computed a successful path intent and conveys this to the spot service.
   "SetDynamicPathIdV1":
   {
     "StartPlaceId": 731889,
-    "StartPlaceId": 731858,
+    "EndPlaceId": 731257,
     "DynamicPathId": 58311
   }
 }
@@ -49,7 +49,7 @@ AHS was unsuccessful at finding a theoretical path to reach the place.
   "SetDynamicPathIdV1":
   {
     "StartPlaceId": 731889,
-    "StartPlaceId": 731858,
+    "EndPlaceId": 731257,
     "DynamicPathId": 0
   }
 }
@@ -69,7 +69,7 @@ AHS wants to remove an intended path or delete an "I can't reach the place".
   "SetDynamicPathIdV1":
   {
     "StartPlaceId": 731889,
-    "StartPlaceId": 731858,
+    "EndPlaceId": 731257,
     "DynamicPathId": null
   }
 }

--- a/specification/SetDynamicPathIDV1.md
+++ b/specification/SetDynamicPathIDV1.md
@@ -17,7 +17,9 @@ This is the method for an AHS to tell **IF** and **HOW** it can reach a Place in
 
 > The Path service is part of the Open-Autonomy family of protocols.  Please reference the Path service documentation for the techincal details.
 
-> NOTE: in the future when there will be more than one AHS operating in the same area using the same Spot service, then this field will have to be replaced by an array[] of {AHS_UUID and PathId} pairs so each AHS can seperately voice their plans or grievances .  Or it coudl be done now at the cost of added complexity.
+> Discussion: We could change the message to be an array of Start-End structures{} as is't quite possible that there will be more than one path to save when a spot is created and there are more than one Primary queues in the area or that multiple staging quesues are used.  But I don't think the added complexity of an array outweighs the benefit of the simplicity of a single path per message.  For instance at boot up an AHS could decide to calcualte and save all the dynamic paths in the mine and that might require some sort of paging if there are too many.
+
+
 
 ## Use Case:
 This message is used when an event triggers it in a very special case under specific circumstances.

--- a/specification/VehicleDismissedV1.md
+++ b/specification/VehicleDismissedV1.md
@@ -1,0 +1,28 @@
+# VehicleDismissedV1
+This message is sent by `LastMileDispatching` when an internal inconsistency or error has occurred.  It tells `AHS` that this vehicle is no longer monitored nor dispatched by the `LastMileDispatching`.  If the vehicle was previously granted `Place` resources, then all resources held by the vehicle is lost and therefore freed in the `LastMileDispatching`.
+
+This message is an extensible message that allows the `LastMileDispatching` to tell `AHS` that it has encountered a snag.  This message allows `AHS` to route the information back to a person for awareness or to handle any exception.  It also notifies `AHS` that the truck needs to re-start the communication from the beginning with [`ApproachingLastMileV1`](ApproachingLastMileV1.md).
+
+
+<br>
+
+|Sender| Triggered by | Triggers|
+|---|---|---|
+| `LastMileDispatching` | `LastMileDispatching` Internal inconsistency or error | `AHS` to re-start communication from `ApproachingLastMileV1` |
+
+<br>
+
+## Message attributes
+|key |value |format | Description|
+|---|:---:|:---:|---|
+|`"VehicleId"`| VehicleId | UUID| The vehicle that is removed and cleared from the `LastMileDispatching`|
+|`"LastMileId"`| `nullable` DispatchingId | UUID| Because this message can be used when `LMD` is inconsistent, the unique ID might be missing or invalid. `AHS` should only use this field for logging purposes and not rely on it for any logic|
+|`"ExceptionId"` | `LMD` Specific | uint_64 | An out of specification, `LastMileDispatching` specific and pre-defined number that the `AHS` can use to match with a human readable description of the problem and/or automate a workflow |
+|`"Description"`|`nullable` Human readable text| string| A human readable error message that explains what problem the `LastMileDispatching` has encountered and possibly a proposed resolution.  This field is optional, but it is expected that if `null`, the `LMD` has provided the AHS with documentation for each ExceptionId number with a description and possibly a remediation to the exception.
+
+
+## Use Case:
+The causes are endless but here are a few:
+* `LastMileDispatching` service has crashed and lost all internal state, but the rest of the system is fine.  Upon re-start, `LMD` will send an `ExpelVehicle` message for each vehicle in the AHS Fleet Definition so both `LastMileDispatching` and `AHS` will now continue with the same internal state.  (Granted this is undesirable, but better than a full system reboot.)
+* a Vehicle sent a valid `LastMileDispatching` message but with inconsistent or invalid PlaceID, WayId or UUID.
+* The `LMD` implementation has an internal limitation and denies access to the `LastMileDispatching` service when the primary queue is full.


### PR DESCRIPTION
Added 2 new messages:
* one that tells the LastMileDispatching that a truck has encountered a problem while spotting, but it does not want to quit.
* one that tells an AHS that a truck has been evicted from the LMD service.  (The truck can start over if it wants to)

The use cases are not fully flushed out, but the messages uses error numbers that will allow the recipient to understand the cause of the problem and the possible remediation or start an automated work flow.